### PR TITLE
add broken_flag in order to build models flagged as broken

### DIFF
--- a/_gen_bconf.py
+++ b/_gen_bconf.py
@@ -1,5 +1,5 @@
 
-def gen_bconf(branch, gt=None, st=None):
+def gen_bconf(branch, gt=None, st=None, broken=False):
     '''
     Provides all information needed by the builder in placing a ``bconf``-file.
 
@@ -24,10 +24,12 @@ def gen_bconf(branch, gt=None, st=None):
         gluon, site = ginit(p)
         gt = gt if gt else gluon.short_commit[0]
         st = st if st else site.short_commit[0]
+        broken = '1' if broken else ''
 
         desc = '-%s%s' %(branch, '-%s' %(get_timestamp(time=False)) if not all(s['common']['branches']['avail'][branch]) else '')
 
         fields=dict(
+            broken_flag=broken,
             call_branch=branch,
             communities=' '.join(s['common']['communities'].keys()),
             gluon_t=gt,
@@ -56,4 +58,4 @@ if __name__ == '__main__':
     from common import prepare_args
 
     a = prepare_args()
-    gen_bconf(a.branch, gt=a.gt, st=a.st)
+    gen_bconf(a.branch, gt=a.gt, st=a.st, broken=a.broken)

--- a/builder.sh
+++ b/builder.sh
@@ -48,7 +48,7 @@ for C in $COMMUNITIES; do
     # Set BUILDBRANCH to your 'stable' Branch. Any 'experimental' or 'beta' user will auto update to the
     # next 'stable' Release, unless the Autoupdater-Settings on the Node are changed.
     $LOGP "~ ${C}_$RELEASE ~ images (GLUON_BRANCH=$BUILDBRANCH GLUON_RELEASE=$RELEASE)" 2>&1 | $LOG
-    $MKCMD GLUON_BRANCH=$BUILDBRANCH GLUON_RELEASE=$RELEASE 2>&1 | $LOG
+    $MKCMD GLUON_BRANCH=$BUILDBRANCH GLUON_RELEASE=$RELEASE BROKEN=$BROKEN 2>&1 | $LOG
 
     # Create a (temporary) manifest
     $LOGP "~ ${C}_$RELEASE ~ manifest (GLUON_BRANCH=$CALLBRANCH GLUON_PRIORITY=$PRIORITY)" 2>&1 | $LOG

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -113,6 +113,11 @@ def prepare_args():
         action='store_true',
         help='Prepare modules in siteconf generator'
     )
+    a.add_argument(
+        '--broken',
+        action='store_true',
+        help='Build also models which are flagged as broken'
+    )
     return a.parse_args()
 
 def log_args():

--- a/common/bconf.tpl
+++ b/common/bconf.tpl
@@ -1,6 +1,7 @@
 # no comment
 
 export AUTOSIGNKEY="${autosign_key}"
+export BROKEN="${broken_flag}"
 export BUILDBRANCH="${build_branch}"
 export BUILDDIR="${build_dir}"
 export CALLBRANCH="${call_branch}"

--- a/docs/preparation.rst
+++ b/docs/preparation.rst
@@ -61,6 +61,7 @@ For example from our first stable release:
 
     {
         "_info": {
+            "broken_flag": "",
             "call_branch": "stable",
             "communities": "wi mz",
             "gluon_t": "b7187df",

--- a/prepare.py
+++ b/prepare.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-def prepare(branch, gt=None, st=None, modules=False):
+def prepare(branch, gt=None, st=None, modules=False, broken=False):
     '''
     Checks out Gluon sources and site-conf repositories at proper commit-ids or tags according to the branch to build.
     Generates a site-conf afterwards.
@@ -55,10 +55,10 @@ def prepare(branch, gt=None, st=None, modules=False):
             verbose=True
         )
 
-    gen_bconf(branch, gt, st)
+    gen_bconf(branch, gt, st, broken)
 
 if __name__ == '__main__':
     from common import prepare_args
 
     a = prepare_args()
-    prepare(a.branch, gt=a.gt, st=a.st, modules=a.modules)
+    prepare(a.branch, gt=a.gt, st=a.st, modules=a.modules, broken=a.broken)


### PR DESCRIPTION
This flag isn't interesting for building stable images, but for the experimental branch I would consider to build images for all available hardware models even if they are flagged as broken.
